### PR TITLE
Declare explicit dependency on 'pywin32' on Windows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Declare explicit dependency on ``pywin32`` on Windows.
+
 
 4.0.1 (2014-12-29)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,15 @@
 import os
 from setuptools import setup, find_packages
 
-tests_require = [
+TESTS_REQUIRE = [
     'zope.security',
     'zope.testing',
 ]
+
+EXTRAS_REQUIRE = {
+    'test': TESTS_REQUIRE,
+    ':sys_platform == "win32"': ['pywin32'],
+}
 
 
 def read(*rnames):
@@ -31,7 +36,7 @@ def read(*rnames):
         return f.read()
 
 
-long_description = (
+LONG_DESCRIPTION = (
     read('README.rst')
     + '\n' +
     read('CHANGES.rst')
@@ -44,7 +49,7 @@ setup(name='zope.sendmail',
       description='Zope sendmail',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
-      long_description=long_description,
+      long_description=LONG_DESCRIPTION,
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
@@ -67,7 +72,7 @@ setup(name='zope.sendmail',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       namespace_packages=['zope'],
-      extras_require=dict(test=tests_require),
+      extras_require=EXTRAS_REQUIRE,
       install_requires=[
           'setuptools',
           'transaction',
@@ -79,7 +84,7 @@ setup(name='zope.sendmail',
           # these are only needed for zcml
           'zope.configuration',
       ],
-      tests_require=tests_require,
+      tests_require=TESTS_REQUIRE,
       test_suite='zope.sendmail.tests',
       include_package_data=True,
       zip_safe=False,


### PR DESCRIPTION
Attempts to use PEP 426 environment marker to install the dependency cleanly (rather than via an imperative check at script scope in `setup.py`). 