### PR TITLE
python3 fix: make sort key a string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes
 4.1.0 (unreleased)
 ------------------
 
+- Make the data manager sort key a string, this fixes Python 3 where
+  strings and integers are not sortable. This would happen when using
+  other data managers with string sort keys.
+
 - Add support for Python 3.5.
 
 - Drop support for Python 2.6.

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -56,7 +56,7 @@ class MailDataManager(object):
             self.onAbort()
 
     def sortKey(self):
-        return id(self)
+        return str(id(self))
 
     # No subtransaction support.
     def abort_sub(self, transaction):

--- a/src/zope/sendmail/tests/test_delivery.py
+++ b/src/zope/sendmail/tests/test_delivery.py
@@ -46,6 +46,8 @@ class TestMailDataManager(TestCase):
         verifyObject(IDataManager, manager)
         self.assertEqual(manager.callable, object)
         self.assertEqual(manager.args, (1, 2))
+        # required by IDataManager
+        self.assertTrue(isinstance(manager.sortKey(), str))
 
     def test_successful_commit(self):
         #Regression test for http://www.zope.org/Collectors/Zope3-dev/590


### PR DESCRIPTION
According to IDataManager sort keys must be strings

https://github.com/zopefoundation/transaction/blob/master/transaction/interfaces.py#L449

This also fixes breakage on python3 as strings and integers are not sortable there and transaction tries to sort them.