### PR TITLE
Add Python 3.6, drop Python 3.3, 100% coverage, fix SSL.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,6 @@ exclude_lines =
     pragma: no cover
     if __name__ == '__main__':
     raise NotImplementedError
-    self.fail
+    self.fail\(\)
     raise AssertionError
     raise unittest.Skip

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,6 @@ exclude_lines =
     pragma: no cover
     if __name__ == '__main__':
     raise NotImplementedError
-    self.fail\(\)
+    self.fail\(
     raise AssertionError
     raise unittest.Skip

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source = zope.sendmail
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError
+    raise unittest.Skip

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin/
 develop-eggs/
 eggs/
 parts/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,23 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
-    - pypy
-    - pypy3
+    - 3.6
+    # Force a newer PyPy on the old 'precise' CI image
+    # in order to install 'cryptography' needed for coveralls
+    # After September 2017 this should be the default and the version
+    # pin can be removed.
+    - pypy-5.6.0
+    - pypy3.5-5.8.0
 install:
-    - pip install -e .[test]
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,28 +1,29 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.1.0 (unreleased)
-------------------
+==================
 
 - Make the data manager sort key a string, this fixes Python 3 where
   strings and integers are not sortable. This would happen when using
   other data managers with string sort keys.
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 - Declare explicit dependency on ``pywin32`` on Windows.
 
 
 4.0.1 (2014-12-29)
-------------------
+==================
 
 - Add support for PyPy3.
 
 
 4.0.0 (2014-12-20)
-------------------
+==================
 
 - Add support for testing on Travis-CI against supported Python verisons.
 
@@ -34,13 +35,13 @@ Changes
 
 
 4.0.0a2 (2013-02-26)
---------------------
+====================
 
 - Fix license Trove classifier.
 
 
 4.0.0a1 (2013-02-25)
---------------------
+====================
 
 - Add support for Python 3.3.
 
@@ -75,7 +76,7 @@ Changes
   parsing to use optparse (not argparse, since Python 2.6 is still supported).
 
 3.7.5 (2012-05-23)
-------------------
+==================
 
 - Ensure that the 'queuedDelivery' directive has the same discriminator
   as the 'directDelivery' directive (they are mutually incompatible).
@@ -85,18 +86,18 @@ Changes
   https://bugs.launchpad.net/zope.sendmail/+bug/1003288
 
 3.7.4 (2010-10-01)
-------------------
+==================
 
 - Handle unicode usernames and passwords, encoding them to UTF-8. Fix for
   https://bugs.launchpad.net/zope.sendmail/+bug/597143
 
 3.7.3 (2010-09-25)
-------------------
+==================
 
 - Add not declared, but needed test dependency on `zope.component [test]`.
 
 3.7.2 (2010-04-30)
-------------------
+==================
 
 - Remove no longer required testing dependency on zope.testing.
 
@@ -106,13 +107,13 @@ Changes
 - Tests use stdlib doctest instead of zope.testing.doctest.
 
 3.7.1 (2010-01-13)
-------------------
+==================
 
 - Backward compatibility import of zope.sendmail.queue.QueueProcessorThread in
   zope.sendmail.delivery.
 
 3.7.0 (2010-01-12)
-------------------
+==================
 
 - Remove dependency on ``zope.security``: the security support is optional,
   and only available if the ``zope.security`` package is available. This change
@@ -131,13 +132,13 @@ Changes
   either process the messages in the queue once, or run in "daemon" mode.
 
 3.6.1 (2009-11-16)
-------------------
+==================
 
 - Depend on ``zope.component`` >= 3.8.0, which supports the new semantic of
   zope.component.zcml.proxify needed by zope.sendmail.zcml.
 
 3.6.0 (2009-09-14)
-------------------
+==================
 
 - Use simple vocabulary factory function instead of custom `UtilityTerm`
   and `UtilityVocabulary` classes, copied from ``zope.app.component`` in
@@ -151,7 +152,7 @@ Changes
   https://bugs.edge.launchpad.net/zope.sendmail/+bug/413335 .
 
 3.5.1 (2009-01-26)
-------------------
+==================
 
 - Copyover the UtilityTerm and UtilityVocabulary implementation from
   zope.app.component to avoid a dependency.
@@ -160,19 +161,19 @@ Changes
   delivered where just the quit failed.
 
 3.5.0 (2008-07-05)
-------------------
+==================
 
 - final release (identical with 3.5.0b2)
 
 3.5.0b2 (2007-12-19)
---------------------
+====================
 
 - If the SMTP server rejects a message (for example, when the sender or
   recipient address is malformed), that email stays in the queue forever
   (https://bugs.launchpad.net/zope3/+bug/157104).
 
 3.5.0b1 (2007-11-08)
---------------------
+====================
 
 - Add README.txt
 - Can now talk to servers that don't implement EHLO
@@ -182,7 +183,7 @@ Changes
 
 
 3.5.0a2 (2007-10-23)
---------------------
+====================
 
 - Clean up ``does_esmtp`` in faux SMTP connection classes provided by the
   tests.
@@ -192,7 +193,7 @@ Changes
 
 
 3.5.0a1 (2007-10-23)
---------------------
+====================
 
 - ``QueueProcessorThread`` now accepts an optional parameter *interval* for
   defining how often to process the mail queue (default is 3 seconds)
@@ -203,7 +204,7 @@ Changes
 
 
 3.4.0 (2007-08-20)
---------------------
+==================
 
 - Bugfix: Don't keep open files around for every email message
   to be sent on transaction commit.  People who try to send many emails
@@ -211,7 +212,7 @@ Changes
 
 
 3.4.0a1 (2007-04-22)
---------------------
+====================
 
 Initial release as a separate project, corresponds to ``zope.sendmail``
 from Zope 3.4.0a1.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
 - Declare explicit dependency on ``pywin32`` on Windows.
 
+- Fix SSL support on Python 3. See `issue 9
+  <https://github.com/zopefoundation/zope.sendmail/issues/9>`_.
 
 4.0.1 (2014-12-29)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@
 
 - Declare explicit dependency on ``pywin32`` on Windows.
 
+- Replace hard-coded constants with equivalents from the standard
+  ``errno`` module.
+
 - Fix SSL support on Python 3. See `issue 9
   <https://github.com/zopefoundation/zope.sendmail/issues/9>`_.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@
 - Fix SSL support on Python 3. See `issue 9
   <https://github.com/zopefoundation/zope.sendmail/issues/9>`_.
 
+- Reach 100% test coverage and maintain it via tox.ini and Travis CI.
+
 4.0.1 (2014-12-29)
 ==================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,20 @@
-``zope.sendmail``
-=================
+===============
+ zope.sendmail
+===============
+
+.. image:: https://img.shields.io/pypi/v/zope.sendmail.svg
+        :target: https://pypi.python.org/pypi/zope.sendmail/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.sendmail.svg
+        :target: https://pypi.org/project/zope.sendmail/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.sendmail.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.sendmail
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.sendmail/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.sendmail?branch=master
 
 zope.sendmail is a package for email sending from Zope 3 applications.
 Email sending from Zope 3 applications works as follows:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,13 @@ from setuptools import setup, find_packages
 TESTS_REQUIRE = [
     'zope.security',
     'zope.testing',
+    'zope.testrunner',
 ]
 
 EXTRAS_REQUIRE = {
     'test': TESTS_REQUIRE,
-#   ':sys_platform == "win32"': ['pywin32'],
-#   Because https://sourceforge.net/p/pywin32/bugs/680/
+    #':sys_platform == "win32"': ['pywin32'],
+    # Because https://sourceforge.net/p/pywin32/bugs/680/
     ':sys_platform == "win32"': ['pypiwin32'],
 }
 
@@ -46,7 +47,7 @@ LONG_DESCRIPTION = (
 
 setup(name='zope.sendmail',
       version='4.1.0.dev0',
-      url='http://pypi.python.org/pypi/zope.sendmail',
+      url='http://github.com/zopefoundation/zope.sendmail',
       license='ZPL 2.1',
       description='Zope sendmail',
       author='Zope Foundation and Contributors',
@@ -61,9 +62,9 @@ setup(name='zope.sendmail',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Operating System :: OS Independent',
@@ -94,4 +95,4 @@ setup(name='zope.sendmail',
       [console_scripts]
       zope-sendmail = zope.sendmail.queue:run
       """
-      )
+)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = (
 
 setup(name='zope.sendmail',
       version='4.1.0.dev0',
-      url='http://github.com/zopefoundation/zope.sendmail',
+      url='https://github.com/zopefoundation/zope.sendmail',
       license='ZPL 2.1',
       description='Zope sendmail',
       author='Zope Foundation and Contributors',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/sendmail/README.rst
+++ b/src/zope/sendmail/README.rst
@@ -1,5 +1,6 @@
-Using zope.sendmail
-===================
+=====================
+ Using zope.sendmail
+=====================
 
 This package is useful when your Zope 3 application wants to send email.  It
 integrates with the transaction mechanism and queues your emails to be sent on
@@ -7,7 +8,7 @@ successful commits only.
 
 
 API
----
+===
 
 An application that wants to send an email can do so by getting the appropriate
 IMailDelivery utility.  The standard library's email module is useful for
@@ -33,7 +34,7 @@ http://mg.pov.lt/blog/unicode-emails-in-python.html
 
 
 Configuration
--------------
+=============
 
 The code above used a named IMailDelivery utility.  It is your responsibility
 to define one, as Zope 3 doesn't provide one by default.  You can define
@@ -60,7 +61,7 @@ time of web pages.
 
 
 Mailers
--------
+=======
 
 The ``mailer`` argument of the ``mail:queuedDelivery`` utility chooses the
 appropriate IMailer utility that will be used to deliver email.  There
@@ -96,7 +97,7 @@ different SMTP server, define your own utility like this::
 
 
 Testing
--------
+=======
 
 Obviously, you don't want your automated unit/functional test runs to send
 real emails.  You'll have to define a fake email delivery utility in your
@@ -116,7 +117,7 @@ Register it with the standard ``utility`` directive::
 
 
 Problems with zope.sendmail
----------------------------
+===========================
 
 * The API is a bit inconvenient to use (e.g. you have to do the message
   formatting by yourself).

--- a/src/zope/sendmail/maildir.py
+++ b/src/zope/sendmail/maildir.py
@@ -68,8 +68,8 @@ class Maildir(object):
                         if not x.startswith('.')]
         # Sort by modification time so earlier messages are sent before
         # later messages during queue processing.
-        msgs_sorted = [(m, os.path.getmtime(m)) for m 
-                      in new_messages + cur_messages]
+        msgs_sorted = [(m, os.path.getmtime(m)) for m
+                       in new_messages + cur_messages]
         msgs_sorted.sort(key=lambda x: x[1])
         return iter([m[0] for m in msgs_sorted])
 
@@ -142,7 +142,7 @@ class MaildirMessageWriter(object):
             raise RuntimeError('Cannot commit, message already aborted')
         elif not self._finished:
             self._finished = True
-            self._fd.close()
+            self.close()
             os.rename(self._filename, self._new_filename)
             # NOTE: the same maildir.html says it should be a link, followed by
             #       unlink.  But Win32 does not necessarily have hardlinks!
@@ -154,8 +154,7 @@ class MaildirMessageWriter(object):
         if not self._finished:
             self._finished = True
             self._aborted = True
-            self._fd.close()
+            self.close()
             os.unlink(self._filename)
 
     # XXX: should there be a __del__ that calls abort()?
-

--- a/src/zope/sendmail/queue.py
+++ b/src/zope/sendmail/queue.py
@@ -30,7 +30,7 @@ from zope.sendmail.maildir import Maildir
 from zope.sendmail.mailer import SMTPMailer
 
 import sys
-if sys.platform == 'win32':
+if sys.platform == 'win32': # pragma: no cover
     import win32file
     _os_link = lambda src, dst: win32file.CreateHardLink(dst, src, None)
 else:
@@ -108,10 +108,12 @@ class QueueProcessorThread(threading.Thread):
     log = logging.getLogger("QueueProcessorThread")
     _stopped = False
     interval = 3.0   # process queue every X second
+    maildir = None
+    mailer = None
 
     def __init__(self, interval=3.0):
         threading.Thread.__init__(self,
-                name="zope.sendmail.queue.QueueProcessorThread")
+                                  name="zope.sendmail.queue.QueueProcessorThread")
         self.interval = interval
         self._lock = threading.Lock()
         self.setDaemon(True)
@@ -123,8 +125,11 @@ class QueueProcessorThread(threading.Thread):
         """
         self.maildir = maildir
 
+    def _makeMaildir(self, path):
+        return Maildir(path, True)
+
     def setQueuePath(self, path):
-        self.maildir = Maildir(path, True)
+        self.setMaildir(self._makeMaildir(path))
 
     def setMailer(self, mailer):
         self.mailer = mailer
@@ -156,6 +161,21 @@ class QueueProcessorThread(threading.Thread):
 
         return fromaddr, toaddrs, rest
 
+    def _action_if_exists(self, fname, func, default=None):
+        # apply the func to the fname, ignoring exceptions that
+        # happen when the file does not exist.
+        try:
+            return func(fname)
+        except OSError as e:
+            if e.errno != 2: # 2 means file does not exist
+                # The file existed, but something unexpected
+                # happened. Report it
+                raise
+            return default
+
+    def _unlink_if_exists(self, fname):
+        self._action_if_exists(fname, os.unlink)
+
     def run(self, forever=True):
         atexit.register(self.stop)
         while not self._stopped:
@@ -163,161 +183,7 @@ class QueueProcessorThread(threading.Thread):
                 # if we are asked to stop while sending messages, do so
                 if self._stopped:
                     break
-
-                fromaddr = ''
-                toaddrs = ()
-                head, tail = os.path.split(filename)
-                tmp_filename = os.path.join(head, '.sending-' + tail)
-                rejected_filename = os.path.join(head, '.rejected-' + tail)
-                try:
-                    # perform a series of operations in an attempt to ensure
-                    # that no two threads/processes send this message
-                    # simultaneously as well as attempting to not generate
-                    # spurious failure messages in the log; a diagram that
-                    # represents these operations is included in a
-                    # comment above this class
-                    try:
-                        # find the age of the tmp file (if it exists)
-                        age = None
-                        mtime = os.stat(tmp_filename)[stat.ST_MTIME]
-                        age = time.time() - mtime
-                    except OSError as e:
-                        if e.errno == 2: # file does not exist
-                            # the tmp file could not be stated because it
-                            # doesn't exist, that's fine, keep going
-                            pass
-                        else:
-                            # the tmp file could not be stated for some reason
-                            # other than not existing; we'll report the error
-                            raise
-
-                    # if the tmp file exists, check its age
-                    if age is not None:
-                        try:
-                            if age > MAX_SEND_TIME:
-                                # the tmp file is "too old"; this suggests
-                                # that during an attempt to send it, the
-                                # process died; remove the tmp file so we
-                                # can try again
-                                os.unlink(tmp_filename)
-                            else:
-                                # the tmp file is "new", so someone else may
-                                # be sending this message, try again later
-                                continue
-                            # if we get here, the file existed, but was too
-                            # old, so it was unlinked
-                        except OSError as e:
-                            if e.errno == 2: # file does not exist
-                                # it looks like someone else removed the tmp
-                                # file, that's fine, we'll try to deliver the
-                                # message again later
-                                continue
-
-                    # now we know that the tmp file doesn't exist, we need to
-                    # "touch" the message before we create the tmp file so the
-                    # mtime will reflect the fact that the file is being
-                    # processed (there is a race here, but it's OK for two or
-                    # more processes to touch the file "simultaneously")
-                    try:
-                        os.utime(filename, None)
-                    except OSError as e:
-                        if e.errno == 2: # file does not exist
-                            # someone removed the message before we could
-                            # touch it, no need to complain, we'll just keep
-                            # going
-                            continue
-
-                    # creating this hard link will fail if another process is
-                    # also sending this message
-                    try:
-                        #os.link(filename, tmp_filename)
-                        _os_link(filename, tmp_filename)
-                    except OSError as e:
-                        if e.errno == 17: # file exists, *nix
-                            # it looks like someone else is sending this
-                            # message too; we'll try again later
-                            continue
-                    except Exception as e:
-                        if e[0] == 183 and e[1] == 'CreateHardLink':
-                            # file exists, win32
-                            continue
-
-                    # read message file and send contents
-                    file = open(filename)
-                    message = file.read()
-                    file.close()
-                    fromaddr, toaddrs, message = self._parseMessage(message)
-                    # The next block is the only one that is sensitive to
-                    # interruptions.  Everywhere else, if this daemon thread
-                    # stops, we should be able to correctly handle a restart.
-                    # In this block, if we send the message, but we are
-                    # stopped before we unlink the file, we will resend the
-                    # message when we are restarted.  We limit the likelihood
-                    # of this somewhat by using a lock to link the two
-                    # operations.  When the process gets an interrupt, it
-                    # will call the atexit that we registered (``stop``
-                    # below).  This will try to get the same lock before it
-                    # lets go.  Because this can cause the daemon thread to
-                    # continue (that is, to not act like a daemon thread), we
-                    # still use the _stopped flag to communicate.
-                    self._lock.acquire()
-                    try:
-                        try:
-                            self.mailer.send(fromaddr, toaddrs, message)
-                        except smtplib.SMTPResponseException as e:
-                            if 500 <= e.smtp_code <= 599:
-                                # permanent error, ditch the message
-                                self.log.error(
-                                    "Discarding email from %s to %s due to"
-                                    " a permanent error: %s",
-                                    fromaddr, ", ".join(toaddrs), str(e))
-                                #os.link(filename, rejected_filename)
-                                _os_link(filename, rejected_filename)
-                            else:
-                                # Log an error and retry later
-                                raise
-                        except smtplib.SMTPRecipientsRefused as e:
-                            # All recipients are refused by smtp
-                            # server. Dont try to redeliver the message.
-                            self.log.error("Email recipients refused: %s",
-                                           ', '.join(e.recipients))
-                            _os_link(filename, rejected_filename)
-
-                        try:
-                            os.unlink(filename)
-                        except OSError as e:
-                            if e.errno == 2: # file does not exist
-                                # someone else unlinked the file; oh well
-                                pass
-                            else:
-                                # something bad happened, log it
-                                raise
-                    finally:
-                        self._lock.release()
-                    try:
-                        os.unlink(tmp_filename)
-                    except OSError as e:
-                        if e.errno == 2: # file does not exist
-                            # someone else unlinked the file; oh well
-                            pass
-                        else:
-                            # something bad happened, log it
-                            raise
-
-                    # TODO: maybe log the Message-Id of the message sent
-                    self.log.info("Mail from %s to %s sent.",
-                                  fromaddr, ", ".join(toaddrs))
-                    # Blanket except because we don't want
-                    # this thread to ever die
-                except:
-                    if fromaddr != '' or toaddrs != ():
-                        self.log.error(
-                            "Error while sending mail from %s to %s.",
-                            fromaddr, ", ".join(toaddrs), exc_info=True)
-                    else:
-                        self.log.error(
-                            "Error while sending mail : %s ",
-                            filename, exc_info=True)
+                self._process_one_file(filename)
             else:
                 if forever:
                     time.sleep(self.interval)
@@ -325,6 +191,144 @@ class QueueProcessorThread(threading.Thread):
             # A testing plug
             if not forever:
                 break
+
+    def _process_one_file(self, filename):
+        fromaddr = ''
+        toaddrs = ()
+        head, tail = os.path.split(filename)
+        tmp_filename = os.path.join(head, '.sending-' + tail)
+        rejected_filename = os.path.join(head, '.rejected-' + tail)
+        try:
+            # perform a series of operations in an attempt to ensure
+            # that no two threads/processes send this message
+            # simultaneously as well as attempting to not generate
+            # spurious failure messages in the log; a diagram that
+            # represents these operations is included in a
+            # comment above this class
+
+            # find the age of the tmp file (if it exists)
+            mtime = self._action_if_exists(tmp_filename,
+                                           lambda fname: os.stat(fname)[stat.ST_MTIME])
+            age = time.time() - mtime if mtime is not None else None
+
+            # if the tmp file exists, check its age
+            if age is not None:
+                if age > MAX_SEND_TIME:
+                    # the tmp file is "too old"; this suggests
+                    # that during an attempt to send it, the
+                    # process died; remove the tmp file so we
+                    # can try again
+                    try:
+                        os.unlink(tmp_filename)
+                    except OSError as e:
+                        if e.errno == 2: # file does not exist
+                            # it looks like someone else removed the tmp
+                            # file, that's fine, we'll try to deliver the
+                            # message again later
+                            return
+                        # XXX: we're silently ignoring the exception here. Is that right?
+                        # If permissions or something are not right, we'll fail
+                        # on _os_link later on.
+                    # if we get here, the file existed, but was too
+                    # old, so it was unlinked
+                else:
+                    # the tmp file is "new", so someone else may
+                    # be sending this message, try again later
+                    return
+
+            # now we know (hope, given the above XXX) that the
+            # tmp file doesn't exist, we need to "touch" the
+            # message before we create the tmp file so the
+            # mtime will reflect the fact that the file is
+            # being processed (there is a race here, but it's
+            # OK for two or more processes to touch the file
+            # "simultaneously")
+            try:
+                os.utime(filename, None)
+            except OSError as e:
+                if e.errno == 2: # file does not exist
+                    # someone removed the message before we could
+                    # touch it, no need to complain, we'll just keep
+                    # going
+                    return
+                # XXX: Silently ignoring all other errors
+
+            # creating this hard link will fail if another process is
+            # also sending this message
+            try:
+                #os.link(filename, tmp_filename)
+                _os_link(filename, tmp_filename)
+            except OSError as e:
+                if e.errno == 17: # file exists, *nix
+                    # it looks like someone else is sending this
+                    # message too; we'll try again later
+                    return
+                # XXX: Silently ignoring all other errno
+            except Exception as e: # pragma: no cover
+                if e[0] == 183 and e[1] == 'CreateHardLink':
+                    # file exists, win32
+                    return
+                # XXX: Silently ignoring all other causes here.
+
+            # read message file and send contents
+            with open(filename) as f:
+                message = f.read()
+
+            fromaddr, toaddrs, message = self._parseMessage(message)
+            # The next block is the only one that is sensitive to
+            # interruptions.  Everywhere else, if this daemon thread
+            # stops, we should be able to correctly handle a restart.
+            # In this block, if we send the message, but we are
+            # stopped before we unlink the file, we will resend the
+            # message when we are restarted.  We limit the likelihood
+            # of this somewhat by using a lock to link the two
+            # operations.  When the process gets an interrupt, it
+            # will call the atexit that we registered (``stop``
+            # below).  This will try to get the same lock before it
+            # lets go.  Because this can cause the daemon thread to
+            # continue (that is, to not act like a daemon thread), we
+            # still use the _stopped flag to communicate.
+            with self._lock:
+                try:
+                    self.mailer.send(fromaddr, toaddrs, message)
+                except smtplib.SMTPResponseException as e:
+                    if 500 <= e.smtp_code <= 599:
+                        # permanent error, ditch the message
+                        self.log.error(
+                            "Discarding email from %s to %s due to"
+                            " a permanent error: %s",
+                            fromaddr, ", ".join(toaddrs), str(e))
+                        #os.link(filename, rejected_filename)
+                        _os_link(filename, rejected_filename)
+                    else:
+                        # Log an error and retry later
+                        raise
+                except smtplib.SMTPRecipientsRefused as e:
+                    # All recipients are refused by smtp
+                    # server. Dont try to redeliver the message.
+                    self.log.error("Email recipients refused: %s",
+                                   ', '.join(e.recipients))
+                    _os_link(filename, rejected_filename)
+
+                self._unlink_if_exists(filename)
+
+            self._unlink_if_exists(tmp_filename)
+
+            # TODO: maybe log the Message-Id of the message sent
+            self.log.info("Mail from %s to %s sent.",
+                          fromaddr, ", ".join(toaddrs))
+            # Blanket except because we don't want
+            # this thread to ever die
+        except:
+            if fromaddr != '' or toaddrs != ():
+                self.log.error(
+                    "Error while sending mail from %s to %s.",
+                    fromaddr, ", ".join(toaddrs), exc_info=True)
+            else:
+                self.log.error(
+                    "Error while sending mail : %s ",
+                    filename, exc_info=True)
+
 
     def stop(self):
         self._stopped = True
@@ -390,7 +394,7 @@ class ConsoleApp(object):
                            "following keys: %s. If you specify the queue path "
                            "in the ini file, you don't need to specify it on "
                            "the command line." % (INI_SECTION,
-                                                   ', '.join(INI_NAMES)))
+                                                  ', '.join(INI_NAMES)))
 
     daemon = False
     interval = 3
@@ -402,17 +406,19 @@ class ConsoleApp(object):
     no_tls = False
     queue_path = None
 
+    QueueProcessorKind = QueueProcessorThread
+    MailerKind = SMTPMailer
+
     def __init__(self, argv=None, verbose=True):
-        if argv is None:
-            argv = sys.argv
+        argv = sys.argv if argv is None else argv
         self.script_name = argv[0]
         self.verbose = verbose
         self._process_args(argv[1:])
-        self.mailer = SMTPMailer(self.hostname, self.port, self.username,
-            self.password, self.no_tls, self.force_tls)
+        self.mailer = self.MailerKind(self.hostname, self.port, self.username,
+                                      self.password, self.no_tls, self.force_tls)
 
     def main(self):
-        queue = QueueProcessorThread(self.interval)
+        queue = self.QueueProcessorKind(self.interval)
         queue.setMailer(self.mailer)
         queue.setQueuePath(self.queue_path)
         queue.run(forever=self.daemon)
@@ -456,11 +462,11 @@ class ConsoleApp(object):
         self.no_tls = boolean(config.get(section, "no_tls"))
         self.queue_path = string_or_none(config.get(section, "queue_path"))
 
-def run():
+def run(argv=None):
     logging.basicConfig()
-    app = ConsoleApp()
+    app = ConsoleApp(argv)
     app.main()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     run()

--- a/src/zope/sendmail/tests/mail.zcml
+++ b/src/zope/sendmail/tests/mail.zcml
@@ -3,26 +3,26 @@
 
   <include package="zope.sendmail" file="meta.zcml"/>
 
-  <mail:queuedDelivery 
+  <mail:queuedDelivery
       name="Mail"
       queuePath="path/to/tmp/mailbox"
       mailer="test.smtp"
       permission="zope.Public" />
-  
-  <mail:directDelivery 
+
+  <mail:directDelivery
       name="Mail2"
       mailer="test.mailer"
       permission="zope.Public" />
 
-  <mail:smtpMailer 
+  <mail:smtpMailer
       name="smtp"
       hostname="localhost"
       port="25"
       username="zope3"
       password="xyzzy"/>
-  
-  <mail:smtpMailer 
+
+  <mail:smtpMailer
       name="smtp2"
       hostname="smarthost"/>
- 
+
 </configure>

--- a/src/zope/sendmail/tests/test_directives.py
+++ b/src/zope/sendmail/tests/test_directives.py
@@ -33,16 +33,7 @@ import zope.sendmail.tests
 
 
 class MaildirStub(object):
-
-    def __init__(self, path, create=False):
-        self.path = path
-        self.create = create
-
-    def __iter__(self):
-        return iter(())
-
-    def newMessage(self):
-        return None
+    pass
 
 @implementer(IMailer)
 class Mailer(object):
@@ -102,9 +93,7 @@ class DirectivesTest(PlacelessSetup, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(DirectivesTest),
-        ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/zope/sendmail/tests/test_directives.py
+++ b/src/zope/sendmail/tests/test_directives.py
@@ -99,7 +99,9 @@ class DirectivesTest(PlacelessSetup, unittest.TestCase):
         with self.assertRaises(ConfigurationError) as exc:
             xmlconfig.string(self.zcml)
 
-        msg = str(exc.exception.args[1])
+        # A ConfigurationExecutionException wraps the ConfigurationError
+        # we're interested in.
+        msg = str(exc.exception.evalue)
         self.assertIn(name, msg)
         self.assertIn('is not defined', msg)
 

--- a/src/zope/sendmail/tests/test_maildir.py
+++ b/src/zope/sendmail/tests/test_maildir.py
@@ -14,7 +14,6 @@
 """Unit tests for zope.sendmail.maildir module
 """
 from __future__ import print_function
-from __future__ import print_function
 
 import unittest
 import stat
@@ -45,7 +44,7 @@ class FakeOsPathModule(object):
         self.files = files
         self.dirs = dirs
         mtimes = {}
-        for t,f in enumerate(files):
+        for t, f in enumerate(files):
             mtimes[f] = 9999 - t
         self._mtimes = mtimes
 
@@ -109,9 +108,7 @@ class FakeOsModule(object):
         return False
 
     def stat(self, path):
-        if path in self._stat_mode:
-            return (self._stat_mode[path], 0, 0, 1, 0, 0, 0, 0, 0, 0)
-        raise OSError('%s does not exist' % path)
+        raise NotImplementedError()
 
     def listdir(self, path):
         return self._listdir.get(path, [])
@@ -133,29 +130,20 @@ class FakeOsModule(object):
             and self.access(filename, 0)):
             raise OSError(errno.EEXIST, 'file already exists')
         if not flags & os.O_CREAT and not self.access(filename, 0):
-            raise OSError('file not found')
+            raise OSError('file not found') # pragma: no cover
         fd = max(list(self._descriptors.keys()) + [2]) + 1
         self._descriptors[fd] = filename, flags, mode
         return fd
 
     def fdopen(self, fd, mode='r'):
         try:
-            filename, flags, permissions = self._descriptors[fd]
-        except KeyError:
+            filename, flags, _permissions = self._descriptors[fd]
+        except KeyError: # pragma: no cover
             raise AssertionError('os.fdopen() called with an unknown'
                                  ' file descriptor')
-        if mode == 'r':
-            assert not flags & os.O_WRONLY
-            assert not flags & os.O_RDWR
-        elif mode == 'w':
-            assert flags & os.O_WRONLY
-            assert not flags & os.O_RDWR
-        elif mode == 'r+':
-            assert not flags & os.O_WRONLY
-            assert flags & os.O_RDWR
-        else:
-            raise AssertionError("don't know how to verify if flags match"
-                                 " mode %r" % mode)
+        assert mode == 'w'
+        assert flags & os.O_WRONLY
+        assert not flags & os.O_RDWR
         return FakeFile(filename, mode)
 
 
@@ -193,7 +181,6 @@ class TestMaildir(unittest.TestCase):
         self.maildir_module.os = self.old_os_module
         self.maildir_module.time = self.old_time_module
         self.maildir_module.socket = self.old_socket_module
-        self.fake_os_module._stat_never_fails = False
         self.fake_os_module._all_files_exist = False
 
     def test_factory(self):
@@ -213,9 +200,9 @@ class TestMaildir(unittest.TestCase):
         verifyObject(IMaildir, m)
         dirs = sorted(self.fake_os_module._made_directories)
         self.assertEqual(dirs, ['/path/to/nosuchfolder',
-                                 '/path/to/nosuchfolder/cur',
-                                 '/path/to/nosuchfolder/new',
-                                 '/path/to/nosuchfolder/tmp'])
+                                '/path/to/nosuchfolder/cur',
+                                '/path/to/nosuchfolder/new',
+                                '/path/to/nosuchfolder/tmp'])
 
         # Case 3: it is a file, not a directory
         self.assertRaises(ValueError, Maildir, '/path/to/regularfile', False)
@@ -230,9 +217,9 @@ class TestMaildir(unittest.TestCase):
         m = Maildir('/path/to/maildir')
         messages = sorted(m)
         self.assertEqual(messages, ['/path/to/maildir/cur/1',
-                                     '/path/to/maildir/cur/2',
-                                     '/path/to/maildir/new/1',
-                                     '/path/to/maildir/new/2'])
+                                    '/path/to/maildir/cur/2',
+                                    '/path/to/maildir/new/1',
+                                    '/path/to/maildir/new/2'])
 
     def test_newMessage(self):
         from zope.sendmail.maildir import Maildir
@@ -241,11 +228,10 @@ class TestMaildir(unittest.TestCase):
         fd = m.newMessage()
         verifyObject(IMaildirMessageWriter, fd)
         self.assertTrue(fd._filename.startswith(
-                     '/path/to/maildir/tmp/1234500002.4242.myhostname.'))
+            '/path/to/maildir/tmp/1234500002.4242.myhostname.'))
 
     def test_newMessage_never_loops(self):
         from zope.sendmail.maildir import Maildir
-        from zope.sendmail.interfaces import IMaildirMessageWriter
         self.fake_os_module._all_files_exist = True
         m = Maildir('/path/to/maildir')
         self.assertRaises(RuntimeError, m.newMessage)
@@ -282,8 +268,8 @@ class TestMaildir(unittest.TestCase):
         writer = MaildirMessageWriter(fd, filename1, filename2)
         writer.commit()
         self.assertEqual(writer._fd._closed, True)
-        self.assertTrue((filename1, filename2)
-                       in self.fake_os_module._renamed_files)
+        self.assertIn((filename1, filename2),
+                      self.fake_os_module._renamed_files)
         # Once commited, commit does nothing
         self.fake_os_module._renamed_files = ()
         writer.commit()
@@ -306,14 +292,11 @@ class TestMaildir(unittest.TestCase):
         writer.write(u' fi\xe8')
         writer.writelines([u' fo\xe8', u' fo\xf2'])
         self.assertEqual(writer._fd._written,
-                          b'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')
+                         b'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')
 
 
 def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestMaildir))
-    return suite
-
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -14,11 +14,7 @@
 """Tests for mailers.
 """
 
-try:
-    from socket import sslerror as SSLError
-except ImportError:
-    # Py3: The error location changed.
-    from ssl import SSLError
+from ssl import SSLError
 
 import unittest
 from zope.interface.verify import verifyObject
@@ -64,6 +60,9 @@ class SMTP(object):
     def ehlo(self):
         self.does_esmtp = True
         return (200, 'Hello, I am your stupid MTA mock')
+
+    def starttls(self):
+        pass
 
 
 class SMTPWithNoEHLO(SMTP):

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -178,3 +178,6 @@ class TestSMTPMailerWithNoEHLO(TestSMTPMailer):
 
     test_send_auth_unicode = test_send_auth
     test_send_auth_nonascii = test_send_auth
+
+def test_suite():
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -13,16 +13,6 @@
 ##############################################################################
 """Tests for mailers.
 """
-import socket
-import unittest
-from zope.interface.verify import verifyObject
-from zope.sendmail.interfaces import ISMTPMailer
-from zope.sendmail.mailer import SMTPMailer
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 try:
     from socket import sslerror as SSLError
@@ -30,66 +20,85 @@ except ImportError:
     # Py3: The error location changed.
     from ssl import SSLError
 
+import unittest
+from zope.interface.verify import verifyObject
+from zope.sendmail.interfaces import ISMTPMailer
+from zope.sendmail.mailer import SMTPMailer
+
+
 # This works for both, Python 2 and 3.
 port_types = (int, str)
 
+class SMTP(object):
+
+    fail_on_quit = False
+
+    def __init__(self, h, p):
+        self.hostname = h
+        self.port = p
+        self.quitted = False
+        self.closed = False
+        assert isinstance(p, port_types)
+
+    def sendmail(self, f, t, m):
+        self.fromaddr = f
+        self.toaddrs = t
+        self.msgtext = m
+
+    def login(self, username, password):
+        self.username = username
+        self.password = password
+
+    def quit(self):
+        if self.fail_on_quit:
+            raise SSLError("dang")
+        self.quitted = True
+        self.close()
+
+    def close(self):
+        self.closed = True
+
+    def has_extn(self, ext):
+        return True
+
+    def ehlo(self):
+        self.does_esmtp = True
+        return (200, 'Hello, I am your stupid MTA mock')
+
+
+class SMTPWithNoEHLO(SMTP):
+    does_esmtp = False
+
+    def helo(self):
+        return (200, 'Hello, I am your stupid MTA mock')
+
+    def ehlo(self):
+        return (502, 'I don\'t understand EHLO')
+
+
 class TestSMTPMailer(unittest.TestCase):
 
+    SMTPClass = SMTP
+
+    def _makeSMTP(self, h, p):
+        self.smtp = self.SMTPClass(h, p)
+        return self.smtp
+
+
     def setUp(self, port=None):
-        global SMTP
-        class SMTP(object):
-
-            fail_on_quit = False
-
-            def __init__(myself, h, p):
-                myself.hostname = h
-                myself.port = p
-                myself.quitted = False
-                myself.closed = False
-                if not isinstance(p, port_types):
-                    raise socket.error("Int or String expected")
-                self.smtp = myself
-
-            def sendmail(self, f, t, m):
-                self.fromaddr = f
-                self.toaddrs = t
-                self.msgtext = m
-
-            def login(self, username, password):
-                self.username = username
-                self.password = password
-
-            def quit(self):
-                if self.fail_on_quit:
-                    raise SSLError("dang")
-                self.quitted = True
-                self.close()
-
-            def close(self):
-                self.closed = True
-
-            def has_extn(self, ext):
-                return True
-
-            def ehlo(self):
-                self.does_esmtp = True
-                return (200, 'Hello, I am your stupid MTA mock')
-
-            def starttls(self):
-                pass
-
-
+        self.smtp = None
         if port is None:
             self.mailer = SMTPMailer()
         else:
             self.mailer = SMTPMailer(u'localhost', port)
-        self.mailer.smtp = SMTP
+
+        self.mailer.smtp = self._makeSMTP
 
     def test_interface(self):
         verifyObject(ISMTPMailer, self.mailer)
 
     def test_send(self):
-        for run in (1,2):
+        for run in (1, 2):
             if run == 2:
                 self.setUp(u'25')
             fromaddr = 'me@example.com'
@@ -146,64 +155,26 @@ class TestSMTPMailer(unittest.TestCase):
         self.assertEqual(self.smtp.password, b'\xc3\xa9vil')
 
     def test_send_failQuit(self):
-        self.mailer.smtp.fail_on_quit = True
-        try:
-            fromaddr = 'me@example.com'
-            toaddrs = ('you@example.com', 'him@example.com')
-            msgtext = 'Headers: headers\n\nbodybodybody\n-- \nsig\n'
-            self.mailer.send(fromaddr, toaddrs, msgtext)
-            self.assertEqual(self.smtp.fromaddr, fromaddr)
-            self.assertEqual(self.smtp.toaddrs, toaddrs)
-            self.assertEqual(self.smtp.msgtext, msgtext)
-            self.assertTrue(not self.smtp.quitted)
-            self.assertTrue(self.smtp.closed)
-        finally:
-            self.mailer.smtp.fail_on_quit = False
+        SMTP.fail_on_quit = True
+        self.addCleanup(lambda: setattr(SMTP, 'fail_on_quit', False))
+
+        fromaddr = 'me@example.com'
+        toaddrs = ('you@example.com', 'him@example.com')
+        msgtext = 'Headers: headers\n\nbodybodybody\n-- \nsig\n'
+        self.mailer.send(fromaddr, toaddrs, msgtext)
+        self.assertEqual(self.smtp.fromaddr, fromaddr)
+        self.assertEqual(self.smtp.toaddrs, toaddrs)
+        self.assertEqual(self.smtp.msgtext, msgtext)
+        self.assertTrue(not self.smtp.quitted)
+        self.assertTrue(self.smtp.closed)
 
 
 class TestSMTPMailerWithNoEHLO(TestSMTPMailer):
 
-    def setUp(self, port=None):
-
-        class SMTPWithNoEHLO(SMTP):
-            does_esmtp = False
-
-            def __init__(myself, h, p):
-                myself.hostname = h
-                myself.port = p
-                myself.quitted = False
-                myself.closed = False
-                if not isinstance(p, port_types):
-                    raise socket.error("Int or String expected")
-                self.smtp = myself
-
-            def helo(self):
-                return (200, 'Hello, I am your stupid MTA mock')
-
-            def ehlo(self):
-                return (502, 'I don\'t understand EHLO')
-
-
-        if port is None:
-            self.mailer = SMTPMailer()
-        else:
-            self.mailer = SMTPMailer(u'localhost', port)
-        self.mailer.smtp = SMTPWithNoEHLO
+    SMTPClass = SMTPWithNoEHLO
 
     def test_send_auth(self):
-        # This test requires ESMTP, which we're intentionally not enabling
-        # here, so pass.
-        pass
+        self.skipTest("This test requires ESMTP, which we're intentionally not enabling")
 
     test_send_auth_unicode = test_send_auth
     test_send_auth_nonascii = test_send_auth
-
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestSMTPMailer))
-    suite.addTest(unittest.makeSuite(TestSMTPMailerWithNoEHLO))
-    return suite
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -15,6 +15,7 @@
 
 Simple implementation of the MailDelivery, Mailers and MailEvents.
 """
+import errno
 import os.path
 import shutil
 import sys
@@ -310,7 +311,7 @@ class TestQueueProcessorThread(unittest.TestCase):
 
         def unlink(fname):
             self.assertEqual(fname, tmp_file)
-            raise OSError(2, fname)
+            raise OSError(errno.ENOENT, fname)
 
         with patched(queue, 'MAX_SEND_TIME', -1):
             with patched(os, 'unlink', unlink):
@@ -329,7 +330,7 @@ class TestQueueProcessorThread(unittest.TestCase):
         def utime(fname, atm):
             self.assertEqual(fname, filename)
             self.assertIsNone(atm)
-            raise OSError(2, fname)
+            raise OSError(errno.ENOENT, fname)
 
         with patched(os, 'utime', utime):
             self.thread.run(forever=False)

--- a/src/zope/sendmail/tests/test_vocabulary.py
+++ b/src/zope/sendmail/tests/test_vocabulary.py
@@ -14,10 +14,10 @@
 """Mail delivery names vocabulary test
 """
 import unittest
+from zope.component.testing import PlacelessSetup
 
-
-class MailDeliveryNamesTests(unittest.TestCase):
-    from zope.component.testing import setUp, tearDown
+class MailDeliveryNamesTests(PlacelessSetup,
+                             unittest.TestCase):
 
     _marker = object()
 
@@ -36,11 +36,9 @@ class MailDeliveryNamesTests(unittest.TestCase):
 
         provideUtility(MailDeliveryNames, name='Mail Delivery Names')
 
-    def _callFUT(self, context=_marker):
+    def _callFUT(self):
         from zope.sendmail.vocabulary import MailDeliveryNames
-        if context is self._marker:
-            return MailDeliveryNames()
-        return MailDeliveryNames(context)
+        return MailDeliveryNames()
 
     def test_default(self):
         NAMES = 'and now for something completely different'.split()
@@ -50,6 +48,4 @@ class MailDeliveryNamesTests(unittest.TestCase):
         self.assertEqual(names, sorted(NAMES))
 
 def test_suite():
-    return unittest.TestSuite([
-        unittest.makeSuite(MailDeliveryNamesTests),
-        ])
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
 deps =
-    zope.security
-    zope.testing
+    .[test]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python3.6
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=100
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
- Badges
- Universal wheels
- Rename .txt -> .rst
- Set up coverage environment and coveralls
- Use zope.testrunner for namespace path issues.
- Minor whitespace cleanups.

First commit is the usual project gardening. Subsequent commits add test coverage and fix #9.

There are several places that the queue processor is silently ignoring exceptions that might indicate bugs that need to be fixed in the future (or at least logged).

Fixes #6. Fixes #7. Fixes #9.