### PR TITLE
Fix tox -e coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 source = zope.sendmail
+plugins = coverage_python_version
 
 [report]
 precision = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           sudo: true
 install:
     - pip install -U pip setuptools
-    - pip install -U coverage coveralls
+    - pip install -U coverage coveralls coverage-python-version
     - pip install -U -e .[test]
 script:
     - coverage run -m zope.testrunner --test-path=src

--- a/src/zope/sendmail/_compat.py
+++ b/src/zope/sendmail/_compat.py
@@ -1,6 +1,6 @@
 try:
     text_type = unicode
-    PY2 = True
-except NameError:  # pragma: NO COVER Py3k
+    PY2 = True     # pragma: PY2
+except NameError:  # pragma: PY3
     text_type = str
     PY2 = False

--- a/src/zope/sendmail/mailer.py
+++ b/src/zope/sendmail/mailer.py
@@ -102,9 +102,9 @@ class SMTPMailer(object):
             if self.username is not None and self.password is not None:
                 username, password = self.username, self.password
                 if PY2 and isinstance(username, text_type):
-                    username = username.encode('utf-8')
+                    username = username.encode('utf-8')  # pragma: PY2
                 if PY2 and isinstance(password, text_type):
-                    password = password.encode('utf-8')
+                    password = password.encode('utf-8')  # pragma: PY2
                 connection.login(username, password)
         elif self.username:
             raise RuntimeError('Mailhost does not support ESMTP but a username '

--- a/src/zope/sendmail/queue.py
+++ b/src/zope/sendmail/queue.py
@@ -39,7 +39,7 @@ else:
 
 try:
     import ConfigParser as configparser
-except ImportError:
+except ImportError:  # pragma: PY3
     import configparser
 
 # The longest time sending a file is expected to take.  Longer than this and

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands =
 deps =
     {[testenv]deps}
     coverage
+    coverage-python-version
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
In a recent PR we added some lines of code that are executed under Python 2 only.  This caused tox -e coverage to fail.

(It caused no problems for coveralls, because they merge the coverages of all Python versions.)

Let's use the coverage-python-version plugin so we can annotate blocks of code that are Python version specific, so that coverage will be 100% irrespective of which Python version you use to run the tests.