### PR TITLE
Fix text/bytes issue in MailDir for Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.2.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix text/bytes issue in MailDir for Python 3.
 
 
 4.2.1 (2019-02-07)

--- a/src/zope/sendmail/maildir.py
+++ b/src/zope/sendmail/maildir.py
@@ -114,7 +114,7 @@ class Maildir(object):
 
 def _encode_utf8(s):
     if PY2 and isinstance(s, text_type):
-        s = s.encode('utf-8')
+        s = s.encode('utf-8')  # pragma: PY2
     return s
 
 

--- a/src/zope/sendmail/maildir.py
+++ b/src/zope/sendmail/maildir.py
@@ -24,6 +24,7 @@ from zope.interface import implementer, provider
 from zope.sendmail.interfaces import \
      IMaildirFactory, IMaildir, IMaildirMessageWriter
 from zope.sendmail._compat import text_type
+from zope.sendmail._compat import PY2
 
 
 @provider(IMaildirFactory)
@@ -112,7 +113,7 @@ class Maildir(object):
 
 
 def _encode_utf8(s):
-    if isinstance(s, text_type):
+    if PY2 and isinstance(s, text_type):
         s = s.encode('utf-8')
     return s
 

--- a/src/zope/sendmail/tests/test_maildir.py
+++ b/src/zope/sendmail/tests/test_maildir.py
@@ -305,8 +305,9 @@ class TestMaildir(unittest.TestCase):
         writer.write(u' fi\xe8')
         writer.writelines([u' fo\xe8', u' fo\xf2'])
         if PY2:
-            self.assertEqual(writer._fd._written,
-                             'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')
+            self.assertEqual(
+                writer._fd._written,
+                'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')  # pragma: PY2
         else:
             self.assertEqual(writer._fd._written,
                              'fe\xe8 fi\xe8 fo\xe8 fo\xf2')

--- a/src/zope/sendmail/tests/test_maildir.py
+++ b/src/zope/sendmail/tests/test_maildir.py
@@ -24,6 +24,7 @@ from zope.interface.verify import verifyObject
 
 from zope.sendmail.maildir import Maildir
 from zope.sendmail.interfaces import IMaildirMessageWriter
+from zope.sendmail._compat import PY2
 
 
 class FakeSocketModule(object):
@@ -157,7 +158,7 @@ class FakeFile(object):
     def __init__(self, filename, mode):
         self._filename = filename
         self._mode = mode
-        self._written = b''
+        self._written = ''
         self._closed = False
 
     def close(self):
@@ -167,7 +168,7 @@ class FakeFile(object):
         self._written += data
 
     def writelines(self, lines):
-        self._written += b''.join(lines)
+        self._written += ''.join(lines)
 
 
 class TestMaildir(unittest.TestCase):
@@ -259,7 +260,7 @@ class TestMaildir(unittest.TestCase):
         print('fee', end='', file=writer)
         writer.write(' fie')
         writer.writelines([' foe', ' foo'])
-        self.assertEqual(writer._fd._written, b'fee fie foe foo')
+        self.assertEqual(writer._fd._written, 'fee fie foe foo')
 
         writer.abort()
         self.assertTrue(writer._fd._closed)
@@ -303,7 +304,11 @@ class TestMaildir(unittest.TestCase):
         print(u'fe\xe8', end='', file=writer)
         writer.write(u' fi\xe8')
         writer.writelines([u' fo\xe8', u' fo\xf2'])
-        self.assertEqual(writer._fd._written,
-                         b'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')
+        if PY2:
+            self.assertEqual(writer._fd._written,
+                             'fe\xc3\xa8 fi\xc3\xa8 fo\xc3\xa8 fo\xc3\xb2')
+        else:
+            self.assertEqual(writer._fd._written,
+                             'fe\xe8 fi\xe8 fo\xe8 fo\xf2')
         writer.close()
         self.assertTrue(writer._fd._closed)


### PR DESCRIPTION
`Maildir.newMessage` returns a MaildirMessageWriter with a file handle opened
in text mode, see
https://github.com/zopefoundation/zope.sendmail/blob/2ee8b0a454ff484335e6b65b9d46a695309a2b2f/src/zope/sendmail/maildir.py#L110
(mode is 'w' not 'wb')

But `MaildirMessageWriter.write` writes bytes to this file handle, see
https://github.com/zopefoundation/zope.sendmail/blob/2ee8b0a454ff484335e6b65b9d46a695309a2b2f/src/zope/sendmail/maildir.py#L131-L132

This commit changes the implementation to use text for Python 3.

The change is necessary to get the tests in zopefoundation/Products.MailHost#15 green.