### PR TITLE
Fix text/bytes issue in MailDir for Python 3 – 2nd approach

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 ==================
 
 - Fix text/bytes issue in MailDir for Python 3.
+  (`#24 <https://github.com/zopefoundation/zope.sendmail/pull/24>`_)
 
 
 4.2.1 (2019-02-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.2.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix text/bytes issue in MailDir for Python 3.
 
 
 4.2.1 (2019-02-07)

--- a/src/zope/sendmail/maildir.py
+++ b/src/zope/sendmail/maildir.py
@@ -107,7 +107,7 @@ class Maildir(object):
                 time.sleep(0.1)
             else:
                 break
-        return MaildirMessageWriter(os.fdopen(fd, 'w'), filename,
+        return MaildirMessageWriter(os.fdopen(fd, 'wb'), filename,
                                     join(subdir_new, unique))
 
 

--- a/src/zope/sendmail/tests/test_maildir.py
+++ b/src/zope/sendmail/tests/test_maildir.py
@@ -146,7 +146,7 @@ class FakeOsModule(object):
         except KeyError:  # pragma: no cover
             raise AssertionError('os.fdopen() called with an unknown'
                                  ' file descriptor')
-        assert mode == 'w'
+        assert mode == 'wb'
         assert flags & os.O_WRONLY
         assert not flags & os.O_RDWR
         return FakeFile(filename, mode)

--- a/src/zope/sendmail/tests/test_maildir.py
+++ b/src/zope/sendmail/tests/test_maildir.py
@@ -157,7 +157,7 @@ class FakeFile(object):
     def __init__(self, filename, mode):
         self._filename = filename
         self._mode = mode
-        self._written = b''
+        self._written = b'' if 'b' in mode else ''
         self._closed = False
 
     def close(self):
@@ -252,10 +252,10 @@ class TestMaildir(unittest.TestCase):
         from zope.sendmail.maildir import MaildirMessageWriter
         filename1 = '/path/to/maildir/tmp/1234500002.4242.myhostname'
         filename2 = '/path/to/maildir/new/1234500002.4242.myhostname'
-        fd = FakeFile(filename1, 'w')
+        fd = FakeFile(filename1, 'wb')
         writer = MaildirMessageWriter(fd, filename1, filename2)
         self.assertEqual(writer._fd._filename, filename1)
-        self.assertEqual(writer._fd._mode, 'w')  # TODO or 'wb'?
+        self.assertEqual(writer._fd._mode, 'wb')
         print('fee', end='', file=writer)
         writer.write(' fie')
         writer.writelines([' foe', ' foo'])
@@ -296,10 +296,10 @@ class TestMaildir(unittest.TestCase):
         from zope.sendmail.maildir import MaildirMessageWriter
         filename1 = '/path/to/maildir/tmp/1234500002.4242.myhostname'
         filename2 = '/path/to/maildir/new/1234500002.4242.myhostname'
-        fd = FakeFile(filename1, 'w')
+        fd = FakeFile(filename1, 'wb')
         writer = MaildirMessageWriter(fd, filename1, filename2)
         self.assertEqual(writer._fd._filename, filename1)
-        self.assertEqual(writer._fd._mode, 'w')  # TODO or 'wb'?
+        self.assertEqual(writer._fd._mode, 'wb')
         print(u'fe\xe8', end='', file=writer)
         writer.write(u' fi\xe8')
         writer.writelines([u' fo\xe8', u' fo\xf2'])


### PR DESCRIPTION
`Maildir.newMessage` returns a MaildirMessageWriter with a file handle opened in text mode, see
https://github.com/zopefoundation/zope.sendmail/blob/2ee8b0a454ff484335e6b65b9d46a695309a2b2f/src/zope/sendmail/maildir.py#L110
(mode is 'w' not 'wb')

But `MaildirMessageWriter.write` writes bytes to this file handle, see
https://github.com/zopefoundation/zope.sendmail/blob/2ee8b0a454ff484335e6b65b9d46a695309a2b2f/src/zope/sendmail/maildir.py#L131-L132

This commit changes the implementation to use bytes for Python 3.

The change is necessary to get the tests in zopefoundation/Products.MailHost#15 green.

Closes #23. (Which had a different implementation.)