### PR TITLE
Add support for Python 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: python
-sudo: false
+dist: xenial
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
-    - pypy
-    - pypy3
+    - 3.7
+    - 3.8-dev
+    - pypy2.7-6.0
+    - pypy3.5-6.0
 matrix:
     include:
-        - python: "3.7"
-          dist: xenial
-          sudo: true
         - name: "flake8"
           install: pip install flake8
           script: flake8 src setup.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,12 @@
  Changes
 =========
 
-4.2.2 (unreleased)
-==================
+5.0 (unreleased)
+================
+
+- Drop support for Python 3.4.
+
+- Add support for Python 3.8a3.
 
 - Fix text/bytes issue in MailDir for Python 3.
   (`#24 <https://github.com/zopefoundation/zope.sendmail/pull/24>`_)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ LONG_DESCRIPTION = (
 
 setup(
     name='zope.sendmail',
-    version='4.2.2.dev0',
+    version='5.0.dev0',
     url='https://github.com/zopefoundation/zope.sendmail',
     license='ZPL 2.1',
     description='Zope sendmail',
@@ -68,10 +68,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
@@ -82,6 +82,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope'],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     extras_require=EXTRAS_REQUIRE,
     install_requires=[
         'setuptools',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-   flake8,py27,py34,py35,py36,py37,pypy,pypy3,coverage,docs
+   flake8,py27,py35,py36,py37,py38,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =
@@ -11,7 +11,7 @@ deps =
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python3.6
+    python3.7
 commands =
     coverage run -m zope.testrunner --test-path=src []
     coverage report --fail-under=100


### PR DESCRIPTION
Drop support for 3.4 as zope.testrunner no longer supports it.