### PR TITLE
Work with messages as bytes

### DIFF
--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -110,7 +110,11 @@ class AbstractMailDelivery(object):
         else:
             if not isinstance(message, bytes):
                 message = message.encode('utf-8')
-            header = message.split(b'\n\n')[0]
+            # determine line separator type (assumes consistency)
+            nli = message.find(b'\n')
+            line_sep = b'\n' if nli < 1 or message[nli - 1] != b'\r' \
+                 else b'\r\n'
+            header = message.split(line_sep * 2, 1)[0]
 
         if bytes is str:
             parse = email.parser.Parser().parsestr  # pragma: PY2

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -113,9 +113,9 @@ class AbstractMailDelivery(object):
             header = message.split(b'\n\n')[0]
 
         if bytes is str:
-            parse = email.parser.Parser().parsestr
+            parse = email.parser.Parser().parsestr  # pragma: PY2
         else:
-            parse = email.parser.BytesParser().parsebytes
+            parse = email.parser.BytesParser().parsebytes  # pragma: PY3
         messageid = parse(header).get('Message-Id')
         if messageid:
             if not messageid.startswith('<') or not messageid.endswith('>'):

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -35,6 +35,7 @@ from zope.sendmail.maildir import Maildir
 # BBB: this import is needed for backward compatibility with older versions of
 # zope.sendmail which defined QueueProcessorThread in this module
 from zope.sendmail.queue import QueueProcessorThread  # noqa: F401
+from ._compat import PY2
 
 
 log = logging.getLogger("MailDataManager")
@@ -116,7 +117,7 @@ class AbstractMailDelivery(object):
                 else b'\r\n'
             header = message.split(line_sep * 2, 1)[0]
 
-        if bytes is str:
+        if PY2:
             parse = email.parser.Parser().parsestr  # pragma: PY2
         else:
             parse = email.parser.BytesParser().parsebytes  # pragma: PY3

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -113,7 +113,7 @@ class AbstractMailDelivery(object):
             # determine line separator type (assumes consistency)
             nli = message.find(b'\n')
             line_sep = b'\n' if nli < 1 or message[nli - 1] != b'\r' \
-                 else b'\r\n'
+                else b'\r\n'
             header = message.split(line_sep * 2, 1)[0]
 
         if bytes is str:

--- a/src/zope/sendmail/queue.py
+++ b/src/zope/sendmail/queue.py
@@ -149,11 +149,6 @@ class QueueProcessorThread(threading.Thread):
         toaddrs = ()
         rest = ""
 
-        # The most common use case is to use UTF-8 encoding. If something else
-        # is needed, pass bytes
-        if not isinstance(message, bytes):
-            message = message.encode('utf-8')
-
         try:
             first, second, rest = message.split(b'\n', 2)
         except ValueError:

--- a/src/zope/sendmail/tests/test_delivery.py
+++ b/src/zope/sendmail/tests/test_delivery.py
@@ -131,7 +131,7 @@ class TestDirectMailDelivery(unittest.TestCase):
         verifyObject(IDirectMailDelivery, delivery)
         self.assertEqual(delivery.mailer, mailer)
 
-    def testSend(self, send_unicode=False):
+    def testSend(self, send_unicode=False, message=None):
         mailer = MailerStub()
         delivery = DirectMailDelivery(mailer)
         fromaddr = 'Jim <jim@example.com'
@@ -141,9 +141,10 @@ class TestDirectMailDelivery(unittest.TestCase):
                        b'To: some-zope-coders:;\n'
                        b'Date: Mon, 19 May 2003 10:17:36 -0400\n'
                        b'Message-Id: <20030519.1234@example.org>\n')
-        message = (b'Subject: example\n'
-                   b'\n'
-                   b'This is just an example\n')
+        if message is None:
+            message = (b'Subject: example\n'
+                       b'\n'
+                       b'This is just an example\n')
 
         if send_unicode:
             opt_headers_bytes = opt_headers
@@ -182,6 +183,17 @@ class TestDirectMailDelivery(unittest.TestCase):
 
     def testSendUnicode(self):
         self.testSend(send_unicode=True)
+
+    def testSendLatin1(self):
+        '''
+        Test to send a mail that is not valid UTF-8. Since we are using bytes
+        everywhere, this is not a problem.
+        '''
+        message = (b'Subject: example\n'
+                   b'Content-Type: text/plain; charset="latin1"\n'
+                   b'\n'
+                   b'\xfc')
+        self.testSend(message=message)
 
     def testBrokenMailerErrorsAreEaten(self):
         from zope.testing.loggingsupport import InstalledHandler

--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -143,18 +143,18 @@ class TestQueueProcessorThread(unittest.TestCase):
                          "zope.sendmail.queue.QueueProcessorThread")
 
     def test_parseMessage(self):
-        hdr = ('X-Zope-From: foo@example.com\n'
-               'X-Zope-To: bar@example.com, baz@example.com\n')
-        msg = ('Header: value\n'
-               '\n'
-               'Body\n')
+        hdr = (b'X-Zope-From: foo@example.com\n'
+               b'X-Zope-To: bar@example.com, baz@example.com\n')
+        msg = (b'Header: value\n'
+               b'\n'
+               b'Body\n')
         f, t, m = self.thread._parseMessage(hdr + msg)
         self.assertEqual(f, 'foo@example.com')
         self.assertEqual(t, ('bar@example.com', 'baz@example.com'))
         self.assertEqual(m, msg)
 
     def test_parseMessage_error(self):
-        msg = "bad message"
+        msg = b"bad message"
         f, t, m = self.thread._parseMessage(msg)
         self.assertEqual(f, "")
         self.assertEqual(t, ())


### PR DESCRIPTION
This is based on the discussion in
`https://github.com/zopefoundation/Products.MailHost/issues/30`
and
`https://github.com/zopefoundation/Products.MailHost/pull/32`.

In order to allow messages with 8bit-encoding to be sent using smtplib,
they have to be prepared as bytes. Since any preparation and header
parsing and manipulation is done in `Products.MailHost`, `zope.sendmail`
only needs to store messages internally as bytes and allow them to be
passed as bytes.

I have not yet added new tests for this added functionality, only fixed the
existing ones.