### PR TITLE
fixes #30

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@
 5.1 (unreleased)
 ================
 
-- Nothing changed yet.
-
+- Use ``pywin32`` again, not any longer the meanwhile outdated fork named ``pypiwin32``.
+  Add some information for installation with buildout.
+  (`#30 <https://github.com/zopefoundation/zope.sendmail/blob/master/docs/usage.rst>`_)
 
 5.0 (2019-04-03)
 ================

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,7 @@ TESTS_REQUIRE = [
 
 EXTRAS_REQUIRE = {
     'test': TESTS_REQUIRE,
-    # ':sys_platform == "win32"': ['pywin32'],
-    # Because https://sourceforge.net/p/pywin32/bugs/680/
-    ':sys_platform == "win32"': ['pypiwin32'],
+    ':sys_platform == "win32"': ['pywin32'],
     'docs': [
         'Sphinx',
         'repoze.sphinx.autointerface',

--- a/src/zope/sendmail/README.rst
+++ b/src/zope/sendmail/README.rst
@@ -7,6 +7,14 @@ integrates with the transaction mechanism and queues your emails to be sent on
 successful commits only.
 
 
+Installation on Windows/ Buildout
+=================================
+
+When using Windows, `pywin32 <https://github.com/mhammond/pywin32>`_ is required.
+``pywin32`` can only be installed using ``pip``, it **does not work with ``zc.buildout``**.
+When using buildout, prior to the execution of buildout, use ``pip`` to install ``pywin32``.
+
+
 API
 ===
 


### PR DESCRIPTION
Use ``pywin32`` again, not any longer the meanwhile outdated fork named ``pypiwin32``.
 Add some information for installation with buildout.