### PR TITLE
Fix deprecation warning happening with Python 3.10+

### DIFF
--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -139,7 +139,12 @@ class TestQueueProcessorThread(unittest.TestCase):
         self.assertTrue(os.path.exists(md.path))
 
     def test_threadName(self):
-        self.assertEqual(self.thread.getName(),
+        try:
+            thread_name = self.thread.name
+        except AttributeError:
+            # Deprecated since Python 3.10
+            thread_name = self.thread.getName()
+        self.assertEqual(thread_name,
                          "zope.sendmail.queue.QueueProcessorThread")
 
     def test_parseMessage(self):

--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -139,12 +139,7 @@ class TestQueueProcessorThread(unittest.TestCase):
         self.assertTrue(os.path.exists(md.path))
 
     def test_threadName(self):
-        try:
-            thread_name = self.thread.name
-        except AttributeError:
-            # Deprecated since Python 3.10
-            thread_name = self.thread.getName()
-        self.assertEqual(thread_name,
+        self.assertEqual(self.thread.name,
                          "zope.sendmail.queue.QueueProcessorThread")
 
     def test_parseMessage(self):


### PR DESCRIPTION
See https://docs.python.org/3/library/threading.html#threading.Thread.getName

Closes #46