### PR TITLE
Added misssing CR in mail header line break

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 6.1 (unreleased)
 ================
 
+- Fix SMTP protocol interoperability by avoiding hardcoded line endings.
+  (see https://www.rfc-editor.org/rfc/rfc2821#section-2.3.7)
+
 - Add preliminary support for Python 3.13 as of 3.13a3.
 
 - Add support for Python 3.12.

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -138,7 +138,7 @@ class AbstractMailDelivery:
             messageid = messageid[1:-1]
         else:
             messageid = self.newMessageId()
-            message = b'Message-Id: <%s>\n%s' % (messageid.encode(), message)
+            message = b'Message-Id: <%s>\r\n%s' % (messageid.encode(), message)
         transaction.get().join(
             self.createDataManager(fromaddr, toaddrs, message))
         return messageid

--- a/src/zope/sendmail/delivery.py
+++ b/src/zope/sendmail/delivery.py
@@ -121,12 +121,13 @@ class AbstractMailDelivery:
         # peculiarities should be handled before.
         if message is None:
             header = b''
+            line_sep = b'\r\n'
         else:
             if not isinstance(message, bytes):
                 message = message.encode('utf-8')
             # determine line separator type (assumes consistency)
             nli = message.find(b'\n')
-            line_sep = b'\n' if nli < 1 or message[nli - 1] != b'\r' \
+            line_sep = b'\n' if nli < 1 or message[nli-1:nli] != b'\r' \
                 else b'\r\n'
             header = message.split(line_sep * 2, 1)[0]
 
@@ -138,7 +139,8 @@ class AbstractMailDelivery:
             messageid = messageid[1:-1]
         else:
             messageid = self.newMessageId()
-            message = b'Message-Id: <%s>\r\n%s' % (messageid.encode(), message)
+            message = b'Message-Id: <%s>%s%s' % (
+                messageid.encode(), line_sep, message)
         transaction.get().join(
             self.createDataManager(fromaddr, toaddrs, message))
         return messageid


### PR DESCRIPTION
Ref: https://www.rfc-editor.org/rfc/rfc2821#section-2.3.7

Email-servers may reject not standard conformant data streams. 