### PR TITLE
implicit_tls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@
 
 - Add implicit_tls option to the Mailer, if setted to True the SMTP connection will use smtplib.SMTP_SSL
   and starts the connection with SSL from the beginning.
-  (see https://datatracker.ietf.org/doc/html/rfc8314#section-3.3)
+  (see `RFC8314 <https://datatracker.ietf.org/doc/html/rfc8314#section-3.3>`_)
 
 6.1 (2024-02-07)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 6.2 (unreleased)
 ================
 
+- Add implicit_tls option to the Mailer, if setted to True the SMTP connection will use smtplib.SMTP_SSL
+  and starts the connection with SSL from the beginning.
+  (see https://datatracker.ietf.org/doc/html/rfc8314#section-3.3)
 
 6.1 (2024-02-07)
 ================

--- a/src/zope/sendmail/interfaces.py
+++ b/src/zope/sendmail/interfaces.py
@@ -179,7 +179,8 @@ class ISMTPMailer(IMailer):
     implicit_tls = Bool(
         title=_("Implicit TLS"),
         description=_(
-            "Use TLS from the beginning of the connection. "
+            "Use TLS from the beginning of the connection, "
+            "known as SMTPS and commonly used on TCP port 465. "
             "force_tls and no_tls are ignored if this is set."),)
 
 

--- a/src/zope/sendmail/interfaces.py
+++ b/src/zope/sendmail/interfaces.py
@@ -178,7 +178,9 @@ class ISMTPMailer(IMailer):
 
     implicit_tls = Bool(
         title=_("Implicit TLS"),
-        description=_("Use TLS from the beginning of the connection. force_tls and no_tls are ignored if this is set."),)
+        description=_(
+            "Use TLS from the beginning of the connection. "
+            "force_tls and no_tls are ignored if this is set."),)
 
 
 class IMaildirFactory(Interface):

--- a/src/zope/sendmail/interfaces.py
+++ b/src/zope/sendmail/interfaces.py
@@ -176,6 +176,10 @@ class ISMTPMailer(IMailer):
         title=_("Force TLS"),
         description=_("Use TLS always for sending email."))
 
+    implicit_tls = Bool(
+        title=_("Implicit TLS"),
+        description=_("Use TLS from the beginning of the connection. force_tls and no_tls are ignored if this is set."),)
+
 
 class IMaildirFactory(Interface):
 

--- a/src/zope/sendmail/mailer.py
+++ b/src/zope/sendmail/mailer.py
@@ -48,8 +48,8 @@ class SMTPMailer:
         self.no_tls = no_tls
         self.implicit_tls = implicit_tls
         self._smtp = _SMTPState()
-        # this is for backwards compatibility, in case someone has been overrided
-        # this class with a custom `smtp` attribute
+        # this is for backwards compatibility, in case someone has been
+        # overrided this class with a custom `smtp` attribute.
         if self.smtp is None:
             self.smtp = SMTP_SSL if self.implicit_tls else SMTP
 

--- a/src/zope/sendmail/mailer.py
+++ b/src/zope/sendmail/mailer.py
@@ -16,6 +16,7 @@
 __docformat__ = 'restructuredtext'
 
 from smtplib import SMTP
+from smtplib import SMTP_SSL
 from ssl import SSLError
 from threading import local
 
@@ -34,17 +35,23 @@ class _SMTPState(local):
 class SMTPMailer:
     """Implementation of :class:`zope.sendmail.interfaces.ISMTPMailer`."""
 
-    smtp = SMTP
+    smtp = None
 
     def __init__(self, hostname='localhost', port=25,
-                 username=None, password=None, no_tls=False, force_tls=False):
+                 username=None, password=None, no_tls=False, force_tls=False,
+                 implicit_tls=False):
         self.hostname = hostname
         self.port = port
         self.username = username
         self.password = password
         self.force_tls = force_tls
         self.no_tls = no_tls
+        self.implicit_tls = implicit_tls
         self._smtp = _SMTPState()
+        # this is for backwards compatibility, in case someone has been overrided
+        # this class with a custom `smtp` attribute
+        if self.smtp is None:
+            self.smtp = SMTP_SSL if self.implicit_tls else SMTP
 
     def _make_property(name):
         return property(lambda self: getattr(self._smtp, name),
@@ -89,13 +96,14 @@ class SMTPMailer:
         connection = self.connection
 
         # encryption support
-        have_tls = connection.has_extn('starttls')
-        if not have_tls and self.force_tls:
-            raise RuntimeError('TLS is not available but TLS is required')
+        if not self.implicit_tls:
+            have_tls = connection.has_extn('starttls')
+            if not have_tls and self.force_tls:
+                raise RuntimeError('TLS is not available but TLS is required')
 
-        if have_tls and not self.no_tls:
-            connection.starttls()
-            connection.ehlo()
+            if have_tls and not self.no_tls:
+                connection.starttls()
+                connection.ehlo()
 
         if connection.does_esmtp:
             if self.username is not None and self.password is not None:

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -284,7 +284,7 @@ class TestSMTPMailer(unittest.TestCase):
                 "Mailhost does not support ESMTP but a username"):
             self.mailer.send(None, None, None)
 
-    def test_mailer_implicit_tsl(self):
+    def test_mailer_implicit_tls(self):
         mailer = SMTPMailer(implicit_tls=True)
         isinstance(mailer.smtp, smtplib.SMTP_SSL)
 

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -296,6 +296,7 @@ class TestSMTPMailer(unittest.TestCase):
         SMTPMailer.smtp = CustomSMTP
         mailer = SMTPMailer()
         self.assertIs(mailer.smtp, CustomSMTP)
+        SMTPMailer.smtp = None
 
 
 class TestSMTPMailerWithNoEHLO(TestSMTPMailer):

--- a/src/zope/sendmail/tests/test_mailer.py
+++ b/src/zope/sendmail/tests/test_mailer.py
@@ -14,6 +14,7 @@
 """Tests for mailers.
 """
 
+import smtplib
 import unittest
 from functools import partial
 from ssl import SSLError
@@ -282,6 +283,19 @@ class TestSMTPMailer(unittest.TestCase):
                 RuntimeError,
                 "Mailhost does not support ESMTP but a username"):
             self.mailer.send(None, None, None)
+
+    def test_mailer_implicit_tsl(self):
+        mailer = SMTPMailer(implicit_tls=True)
+        isinstance(mailer.smtp, smtplib.SMTP_SSL)
+
+    def test_monkeypatch_smtp(self):
+        class CustomSMTP:
+            pass
+
+        # monkeypatching the class
+        SMTPMailer.smtp = CustomSMTP
+        mailer = SMTPMailer()
+        self.assertIs(mailer.smtp, CustomSMTP)
 
 
 class TestSMTPMailerWithNoEHLO(TestSMTPMailer):

--- a/src/zope/sendmail/zcml.py
+++ b/src/zope/sendmail/zcml.py
@@ -177,12 +177,18 @@ class ISMTPMailerDirective(IMailerDirective):
         description="A password for SMTP AUTH.",
         required=False)
 
+    implicit_tls = Bool(
+        title="Implicit TLS",
+        description="Use TLS from the beginning of the connection",
+        required=False,
+        default=False)
+
 
 def smtpMailer(_context, name, hostname="localhost", port="25",
-               username=None, password=None):
+               username=None, password=None, implicit_tls=False):
     _context.action(
         discriminator=('utility', IMailer, name),
         callable=handler,
         args=('registerUtility',
-              SMTPMailer(hostname, port, username, password), IMailer, name)
+              SMTPMailer(hostname, port, username, password, implicit_tls), IMailer, name)
     )

--- a/src/zope/sendmail/zcml.py
+++ b/src/zope/sendmail/zcml.py
@@ -190,5 +190,6 @@ def smtpMailer(_context, name, hostname="localhost", port="25",
         discriminator=('utility', IMailer, name),
         callable=handler,
         args=('registerUtility',
-              SMTPMailer(hostname, port, username, password, implicit_tls), IMailer, name)
+              SMTPMailer(hostname, port, username, password, implicit_tls),
+              IMailer, name)
     )


### PR DESCRIPTION
This is a draft to share the strategy for an implementation that solves https://github.com/zopefoundation/zope.sendmail/issues/53

I added an `implicit_tls` field, to maximize backward compatibility, by default the field is false and the product should behave exactly as it does now. If valued, and the class has not been overridden with an explicit `smtp` engine, SMTP_SSL is used instead of SMTP, the force_tls and no_tls attributes in this case are effectively ignored

No implicit configuration, but everything must be made explicit, any `automatics` could be implemented in higher level libraries (e.g. in Plone)

If the strategy convinces you I can do some test units on the product and on real smtp servers.

\cc @MrTango @d-maurer @dataflake 