### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-6.3 (unreleased)
+7.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 7.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 - Drop support for Python 3.7.

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,13 @@
 """Setup for zope.sendmail package"""
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
 TESTS_REQUIRE = [
     'zope.security',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 EXTRAS_REQUIRE = {
@@ -79,9 +78,6 @@ setup(
         'Topic :: Communications :: Email',
         'Framework :: Zope :: 3',
     ],
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     extras_require=EXTRAS_REQUIRE,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ LONG_DESCRIPTION = (
 
 setup(
     name='zope.sendmail',
-    version='6.3.dev0',
+    version='7.0.dev0',
     url='https://github.com/zopefoundation/zope.sendmail',
     license='ZPL-2.1',
     description='Zope sendmail',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
