### PR TITLE
Improve parsing the config parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 7.1 (unreleased)
 ================
 
+- Support reading the configuration from the standard input.
+  Fix a deprecated warning about the use of ``argparse.FileType`` in Python 3.14.
+  (`#64 <https://github.com/zopefoundation/zope.sendmail/issues/64>`_).
+
 - Move package metadata from setup.py to pyproject.toml.
 
 - Add support for Python 3.14.

--- a/src/zope/sendmail/queue.py
+++ b/src/zope/sendmail/queue.py
@@ -27,6 +27,7 @@ import smtplib
 import sys
 import threading
 import time
+from pathlib import Path
 
 from zope.sendmail.maildir import Maildir
 from zope.sendmail.mailer import SMTPMailer
@@ -355,6 +356,22 @@ def string_or_none(s):
     return s
 
 
+def _config_str(value):
+    """Validate and return a string for --config.
+
+    This preserves the old argparse.FileType() behavior used by this module.
+    """
+
+    if value == '-':
+        return value
+
+    path = Path(value)
+    if path.is_file() and os.access(path, os.R_OK):
+        return value
+
+    raise argparse.ArgumentTypeError(f"can't open '{value}' for reading")
+
+
 class ConsoleApp:
     """Allows running of Queue Processor from the console."""
 
@@ -419,7 +436,7 @@ class ConsoleApp:
     del smtp_group
     parser.add_argument(
         '--config', metavar='<inifile>',
-        type=argparse.FileType(),
+        type=_config_str,
         help=("Get configuration from specified ini file; it must "
               "contain a section [%s] that can contain the "
               "following keys: %s. If you specify the queue path "
@@ -473,9 +490,7 @@ class ConsoleApp:
         self.no_tls = opts.no_tls
 
         if opts.config:
-            fname = opts.config.name
-            opts.config.close()
-            self._load_config(fname)
+            self._load_config(opts.config)
         self.queue_path = opts.maildir or self.queue_path
 
         if not self.queue_path:
@@ -485,11 +500,17 @@ class ConsoleApp:
             self.parser.error('Must use username and password together.')
 
     def _load_config(self, path):
+
         section = self.INI_SECTION
         names = self.INI_NAMES
         defaults = {name: str(getattr(self, name)) for name in names}
         config = configparser.ConfigParser(defaults)
-        config.read(path)
+
+        if path == '-':
+            config.read_file(sys.stdin)
+        else:
+            config.read(path)
+
         self.interval = float(config.get(section, "interval"))
         self.hostname = config.get(section, "hostname")
         self.port = int(config.get(section, "port"))

--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -515,9 +515,31 @@ class TestConsoleApp(unittest.TestCase):
         cmdline = ['sendmail', '--config', 'this path cannot be opened']
         with self.assertRaises(SystemExit) as exc:
             self._make_one(cmdline)
-
-        self.assertIn('No such file or directory', self._get_output())
+        expected = (
+            "argument --config: can't open 'this path cannot be opened' "
+            "for reading"
+        )
+        self.assertEqual(
+            expected,
+            self._get_output().partition("error:")[2].strip())
         self.assertEqual(exc.exception.code, 2)
+
+    def test_ini_parse_stdin(self):
+        cmdline = ['sendmail', '--config', '-']
+        stdin = io.StringIO(test_ini)
+        with patched(sys, 'stdin', stdin):
+            app = self._make_one(cmdline)
+
+        self.assertEqual("sendmail", app.script_name)
+        self.assertEqual("hammer/dont/hurt/em", app.queue_path)
+        self.assertFalse(app.daemon)
+        self.assertEqual(33, app.interval)
+        self.assertEqual("testhost", app.hostname)
+        self.assertEqual(2525, app.port)
+        self.assertEqual("Chris", app.username)
+        self.assertEqual("Rossi", app.password)
+        self.assertFalse(app.force_tls)
+        self.assertTrue(app.no_tls)
 
     def test_run(self):
         cmdline = ['sendmail', self.dir]


### PR DESCRIPTION
It is now possible to pass `--config -` to read the configuration from the standard input.

Remove a deprecation warning happening since Python 3.14.

Fixes https://github.com/zopefoundation/zope.sendmail/issues/64

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.
