### PR TITLE
Fix parsing of the  header when it contains display names with commas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 7.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix parsing of the ``X-Zope-To`` header when it contains display names with commas.
+  (`#68 <https://github.com/zopefoundation/zope.sendmail/issues/68>`_).
 
 
 7.1 (2026-04-24)

--- a/src/zope/sendmail/queue.py
+++ b/src/zope/sendmail/queue.py
@@ -27,6 +27,8 @@ import smtplib
 import sys
 import threading
 import time
+from email.utils import formataddr
+from email.utils import getaddresses
 from pathlib import Path
 
 from zope.sendmail.maildir import Maildir
@@ -162,8 +164,11 @@ class QueueProcessorThread(threading.Thread):
 
         if second.startswith(b"X-Zope-To: "):
             i = len(b"X-Zope-To: ")
+            value = second[i:].decode()
             toaddrs = tuple(
-                addr.decode() for addr in second[i:].split(b", ") if addr
+                formataddr((display_name, address))
+                for display_name, address in getaddresses([value])
+                if address
             )
 
         return fromaddr, toaddrs, rest

--- a/src/zope/sendmail/tests/test_queue.py
+++ b/src/zope/sendmail/tests/test_queue.py
@@ -152,6 +152,22 @@ class TestQueueProcessorThread(unittest.TestCase):
         self.assertEqual(t, ('bar@example.com', 'baz@example.com'))
         self.assertEqual(m, msg)
 
+    def test_parseMessageWithCommaInName(self):
+        hdr = (
+            b'X-Zope-From: foo@example.com\n'
+            b'X-Zope-To: "Bar, Example" <bar@example.com>, '
+            b'"Baz, Example" <baz@example.com>\n')
+        msg = (b'Header: value\n'
+               b'\n'
+               b'Body\n')
+        f, t, m = self.thread._parseMessage(hdr + msg)
+        self.assertEqual(f, 'foo@example.com')
+        self.assertEqual(
+            t,
+            ('"Bar, Example" <bar@example.com>',
+             '"Baz, Example" <baz@example.com>'))
+        self.assertEqual(m, msg)
+
     def test_parseMessage_empty_address(self):
         hdr = (b'X-Zope-From: foo@example.com\n'
                b'X-Zope-To: bar@example.com, , baz@example.com\n')


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/zope.sendmail/issues/68

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.
